### PR TITLE
Copy files if fs.link fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var mkdirp = require('mkdirp')
 var walkSync = require('walk-sync');
 var quickTemp = require('quick-temp')
 var Writer = require('broccoli-writer');
-var helpers = require('broccoli-kitchen-sink-helpers')
+var helpers = require('broccoli-kitchen-sink-helpers');
 
 CachingWriter.prototype = Object.create(Writer.prototype);
 CachingWriter.prototype.constructor = CachingWriter;
@@ -18,21 +18,21 @@ function CachingWriter (inputTree, options) {
 
   for (var key in options) {
     if (options.hasOwnProperty(key)) {
-      this[key] = options[key]
+      this[key] = options[key];
     }
   }
+  this.canLink = testCanLink();
+};
+CachingWriter.prototype.getCacheDir = function () {
+  return quickTemp.makeOrReuse(this, 'tmpCacheDir');
 };
 
-CachingWriter.prototype.getCacheDir = function () {
-  return quickTemp.makeOrReuse(this, 'tmpCacheDir')
-}
-
 CachingWriter.prototype.getCleanCacheDir = function () {
-  return quickTemp.makeOrRemake(this, 'tmpCacheDir')
-}
+  return quickTemp.makeOrRemake(this, 'tmpCacheDir');
+};
 
 CachingWriter.prototype.write = function (readTree, destDir) {
-  var self = this
+  var self = this;
 
   return readTree(this.inputTree).then(function (srcDir) {
     var inputTreeKeys = keysForTree(srcDir);
@@ -54,17 +54,17 @@ CachingWriter.prototype.write = function (readTree, destDir) {
       .finally(function() {
         linkFromCache(self.getCacheDir(), destDir);
       });
-  })
+  });
 };
 
 CachingWriter.prototype.cleanup = function () {
-  quickTemp.remove(this, 'tmpCacheDir')
-  Writer.prototype.cleanup.call(this)
-}
+  quickTemp.remove(this, 'tmpCacheDir');
+  Writer.prototype.cleanup.call(this);
+};
 
 CachingWriter.prototype.updateCache = function (srcDir, destDir) {
   throw new Error('You must implement updateCache.');
-}
+};
 
 module.exports = CachingWriter;
 
@@ -85,49 +85,54 @@ function linkFromCache(srcDir, destDir) {
 
     destFile = path.join(destDir, file);
     mkdirp.sync(path.dirname(destFile));
-    fs.linkSync(srcFile, destFile);
+    if (this.canLink) {
+      fs.linkSync(srcFile, destFile);
+    }
+    else {
+      fs.writeFileSync(destFile, fs.readFileSync(srcFile));
+    }
   }
 }
 
 function keysForTree (fullPath, options) {
   options = options || {}
 
-  var _stack         = options._stack
-  var _followSymlink = options._followSymlink
-  var relativePath   = options.relativePath || '.'
-  var stats
-  var statKeys
+  var _stack         = options._stack;
+  var _followSymlink = options._followSymlink;
+  var relativePath   = options.relativePath || '.';
+  var stats;
+  var statKeys;
 
   try {
     if (_followSymlink) {
-      stats = fs.statSync(fullPath)
+      stats = fs.statSync(fullPath);
     } else {
-      stats = fs.lstatSync(fullPath)
+      stats = fs.lstatSync(fullPath);
     }
   } catch (err) {
-    console.warn('Warning: failed to stat ' + fullPath)
+    console.warn('Warning: failed to stat ' + fullPath);
     // fullPath has probably ceased to exist. Leave `stats` undefined and
     // proceed hashing.
   }
-  var childKeys = []
+  var childKeys = [];
   if (stats) {
-    statKeys = ['stats', stats.mode, stats.size]
+    statKeys = ['stats', stats.mode, stats.size];
   } else {
-    statKeys = ['stat failed']
+    statKeys = ['stat failed'];
   }
   if (stats && stats.isDirectory()) {
-    var fileIdentity = stats.dev + '\x00' + stats.ino
+    var fileIdentity = stats.dev + '\x00' + stats.ino;
     if (_stack != null && _stack.indexOf(fileIdentity) !== -1) {
-      console.warn('Symlink directory loop detected at ' + fullPath + ' (note: loop detection may have false positives on Windows)')
+      console.warn('Symlink directory loop detected at ' + fullPath + ' (note: loop detection may have false positives on Windows)');
     } else {
-      if (_stack != null) _stack = _stack.concat([fileIdentity])
-      var entries
+      if (_stack != null) _stack = _stack.concat([fileIdentity]);
+      var entries;
       try {
-        entries = fs.readdirSync(fullPath).sort()
+        entries = fs.readdirSync(fullPath).sort();
       } catch (err) {
-        console.warn('Warning: Failed to read directory ' + fullPath)
-        console.warn(err.stack)
-        childKeys = ['readdir failed']
+        console.warn('Warning: Failed to read directory ' + fullPath);
+        console.warn(err.stack);
+        childKeys = ['readdir failed'];
         // That's all there is to say about this directory.
       }
       if (entries != null) {
@@ -136,8 +141,8 @@ function keysForTree (fullPath, options) {
           var keys = keysForTree(path.join(fullPath, entries[i]), {
             _stack: _stack,
             relativePath: path.join(relativePath, entries[i])
-          })
-          childKeys = childKeys.concat(keys)
+          });
+          childKeys = childKeys.concat(keys);
         }
       }
     }
@@ -147,16 +152,33 @@ function keysForTree (fullPath, options) {
       // directory loops. _stack is kept null in the absence of symlinks to we
       // don't have to deal with Windows for now, as long as it doesn't use
       // symlinks.
-      _stack = []
+      _stack = [];
     }
-    childKeys = keysForTree(fullPath, {_stack: _stack, relativePath: relativePath, _followSymlink: true}) // follow symlink
-    statKeys.push(stats.mtime.getTime())
+    childKeys = keysForTree(fullPath, {_stack: _stack, relativePath: relativePath, _followSymlink: true}); // follow symlink
+    statKeys.push(stats.mtime.getTime());
   } else if (stats && stats.isFile()) {
-    statKeys.push(stats.mtime.getTime())
+    statKeys.push(stats.mtime.getTime());
   }
 
   // Perhaps we should not use basename to infer the file name
   return ['path', relativePath]
     .concat(statKeys)
-    .concat(childKeys)
+    .concat(childKeys);
+}
+
+
+function testCanLink () {
+  var canLink = false;
+  var canLinkSrc  = path.join(__dirname, "canLinkSrc.tmp");
+  var canLinkDest = path.join(__dirname, "canLinkDest.tmp");
+  try {
+    fs.writeFileSync(canLinkSrc)
+    fs.linkSync(canLinkSrc, canLinkDest);
+    canLink = true;
+  }
+  finally {
+    fs.unlinkSync(canLinkDest);
+    fs.unlinkSync(canLinkSrc);
+  }
+  return canLink;
 }


### PR DESCRIPTION
References #2
- Adds a test and property, `canLink`, to establish whether `fs.link` or `fs.writeFile` should be used
- Semicolons;
