### PR TITLE
Properly test linking of files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,17 +171,23 @@ function keysForTree (fullPath, options) {
 
 
 function testCanLink () {
-  var canLink = false;
   var canLinkSrc  = path.join(__dirname, "canLinkSrc.tmp");
   var canLinkDest = path.join(__dirname, "canLinkDest.tmp");
+
   try {
-    fs.writeFileSync(canLinkSrc)
+    fs.writeFileSync(canLinkSrc);
+  } catch (e) {
+    return false;
+  }
+
+  try {
     fs.linkSync(canLinkSrc, canLinkDest);
-    canLink = true;
-  }
-  finally {
-    fs.unlinkSync(canLinkDest);
+  } catch (e) {
     fs.unlinkSync(canLinkSrc);
+    return false;
   }
-  return canLink;
+
+  fs.unlinkSync(canLinkDest);
+
+  return true;
 }


### PR DESCRIPTION
Previously this code would try to clean up files that didn't necessarily exist, causing the cacher to blow up. I've tested this locally and it should work properly, provided you can unlink a file right after creating it.
