### PR TITLE
Only check cache for included or excluded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,30 @@ call will be used instead.
 
 If you would prefer to perform your plugins work in a non-synchronous way, simply return a promise from `updateCache`.
 
+## Documentation
+
+### `CachingWriter(inputTree, options)`
+
+----
+
+`filterFromCache.include` *{Array of RegExps}*
+
+An array of regular expressions that files and directories in the input tree must pass (match at least one pattern) in order to be included in the cache hash for rebuilds. In other words, a whitelist of patterns that identify which files and/or directories can trigger a rebuild.
+
+
+Default: `[]`
+
+----
+
+`filterFromCache.exclude` *{Array of RegExps}*
+
+An array of regular expressions that files and directories in the input tree cannot pass in order to be included in the cache hash for rebuilds. In other words, a blacklist of patterns that identify which files and/or directories will never trigger a rebuild.
+
+*Note, in the case when a file or directory matches both an include and exlude pattern, the exclude pattern wins*
+
+Default: `[]`
+
+
 ## Switching from `broccoli-writer`
 
 If your broccoli plugin currently extends `broccoli-writer`,
@@ -24,6 +48,7 @@ and you wish to extend `broccoli-caching-writer` instead:
   - Get rid of `readTree`, as `srcDir` is already provided:
     - Code that looks like: `return readTree(this.inputTree).then(function (srcDir) { /* Do the main processing */ });`
     - Simply extract the code, `/* Do the main processing */`, and get rid of the function wrapping it.
+
 
 ## ZOMG!!! TESTS?!?!!?
 


### PR DESCRIPTION
For example, here’s a hypothetical configuration for broccoli-compass so that changing other files (like `*.js` or `*.html`) in a tree does not cause a rebuild:

``` javascript
var outputTree = compileCompass(inputTree, {
  filterFromCache: {
    include: [
      '**/*.{scss,sass}'    // only base the input tree’s hash on *.scss and *.sass files
    ]
  }
});
```

Note, this does _not_ affect what files make it to the output tree at all, rather it only makes it easier for subclasses to only rebuild when file types they care about change.

Also, I'm relatively new to broccoli and its approach to incremental builds, so I'm not sure if it preferred to solve things a different way (such as filtering the tree to only Sass files before it hits this writer?).

ps: I’m not sold at all on the `filterFromCache` name. But I was trying to be explicit and prevent intersecting with existing/future subclasses.
