### PR TITLE
Attempt to cache a tree by the content of the files and not only by their size and mtime.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "javascript"
   ],
   "dependencies": {
-    "broccoli-writer": "~0.1.1",
     "broccoli-kitchen-sink-helpers": "~0.2.0",
+    "broccoli-writer": "~0.1.1",
     "mkdirp": "~0.4.0",
     "quick-temp": "~0.1.2",
-    "walk-sync": "~0.1.2",
-    "rsvp": "~3.0.6"
+    "rimraf": "^2.2.8",
+    "rsvp": "~3.0.6",
+    "walk-sync": "~0.1.2"
   },
   "devDependencies": {
     "mocha": "~1.18.2",


### PR DESCRIPTION
Also, keep old cache directories around so that when you revert to a previous version of a file’s content, you can still use a previous cache. I probably should limit the number of old cache dirs kept around, to prevent the size from getting too crazy big, but haven't implemented it yet.

I'd like to take this even a step further, and keep around cache directories even after the watcher/server is terminated, but this PR is already pretty ambitious (and it seems like that is [not preferred behavior](https://github.com/broccolijs/broccoli#treecleanup) for broccoli).
