### PR TITLE
First pass at pluginify static method.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var quickTemp = require('quick-temp')
 var helpers = require('broccoli-kitchen-sink-helpers');
 var symlinkOrCopy = require('symlink-or-copy');
 var generateRandomString = require('./lib/generate-random-string');
+var CoreObject = require("core-object");
 
 function CachingWriter (inputTrees, options) {
   if (!(this instanceof CachingWriter)) return new CachingWriter(inputTrees, options);
@@ -54,6 +55,7 @@ function CachingWriter (inputTrees, options) {
     throw new Error("Invalid filterFromCache.exclude option, it must be an array or undefined.")
   }
 };
+CachingWriter.__proto__ = CoreObject;
 CachingWriter.prototype.constructor = CachingWriter;
 
 CachingWriter.prototype.enforceSingleInputTree = false;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.2.5",
+    "core-object": "0.0.2",
     "promise-map-series": "^0.2.0",
     "quick-temp": "^0.1.2",
     "rimraf": "^2.2.8",

--- a/tests/index.js
+++ b/tests/index.js
@@ -365,4 +365,36 @@ describe('broccoli-caching-writer', function(){
       expect(tree.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok();
     });
   });
+
+  describe('extend', function() {
+    it('sets the methods correctly', function() {
+      var TestPlugin = cachingWriter.extend({
+        foo: function() {}
+      });
+
+      expect(TestPlugin).to.be.a(Function);
+      expect(TestPlugin.prototype.foo).to.be.a(Function);
+    });
+
+    it('calls CachingWriter constructor', function () {
+      var MyPlugin = cachingWriter.extend({});
+      var instance = new MyPlugin("foo");
+      expect(instance.inputTrees).to.eql(["foo"]);
+    });
+
+    it('can write files to destDir, and they will be in the final output', function(){
+      var TestWriter = cachingWriter.extend({
+        updateCache: function(srcDir, destDir) {
+          fs.writeFileSync(destDir + '/something-cooler.js', 'whoa', {encoding: 'utf8'});
+        }
+      });
+      var tree = new TestWriter(sourcePath);
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(result) {
+        var dir = result.directory;
+        expect(fs.readFileSync(dir + '/something-cooler.js', {encoding: 'utf8'})).to.eql('whoa');
+      });
+    });
+  });
 });


### PR DESCRIPTION
This pull request creates a static method on `CachingWriter` that accepts an object literal of methods/props and an optional description string to generate a class that extends `CachingWriter`, abstracting away all the inheritance ceremony.

Example:

``` javascript
module.exports = CachingWriter.pluginify({
  constructor: function(options) {
    this.customThing = options.customThing;
  },
  updateCache: function(srcDir, destDir) {
    /* Do the main processing */
  }
}, 'MyCustomCachingWriter');
```

Names and conventions are up for debate. Would love your feedback!
