### PR TITLE
Avoid exception during exception handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,9 @@ CachingWriter.prototype.cleanup = function () {
   quickTemp.remove(this, 'tmpCacheDir');
 
   // sadly we must use sync removal for now
-  rimraf.sync(this._destDir);
+  if (this._destDir) {
+    rimraf.sync(this._destDir);
+  }
 };
 
 CachingWriter.prototype.updateCache = function (srcDir, destDir) {


### PR DESCRIPTION
If an exception is thrown somewhere in the build pipeline setup, cleanup
can get called early. If it gets called before we have a _destDir, we
thrown our own exception, which obscures the original exception.
