### PR TITLE
adds support for listing matched files

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -411,4 +411,33 @@ describe('broccoli-caching-writer', function(){
       });
     });
   });
+
+  describe('listFiles', function() {
+    var tree, listFiles;
+
+    beforeEach(function() {
+      tree = new CachingWriter(sourcePath);
+      tree.updateCache = function(srcDir, destDir){
+        listFiles = this.listFiles();
+      }
+    });
+
+    it('returns an array of files keyed', function() {
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function() {
+        expect(listFiles).to.eql(['tests/fixtures/sample-project/core.js',
+                                  'tests/fixtures/sample-project/main.js']);
+        expect(listFiles.length).to.equal(2)
+      });
+    });
+
+    it('returns an array of files keyed ignoring those in the exclude filter', function() {
+      tree.filterFromCache.exclude = [ /main\.js$/ ]
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function() {
+        expect(listFiles).to.eql(['tests/fixtures/sample-project/core.js']);
+        expect(listFiles.length).to.equal(1)
+      });
+    });
+  })
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -431,11 +431,30 @@ describe('broccoli-caching-writer', function(){
       });
     });
 
+    it('returns an array of files keyed including only those in the include filter', function() {
+      tree.filterFromCache.include = [ /core\.js$/ ]
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function() {
+        expect(listFiles).to.eql(['tests/fixtures/sample-project/core.js']);
+        expect(listFiles.length).to.equal(1)
+      });
+    });
+
     it('returns an array of files keyed ignoring those in the exclude filter', function() {
       tree.filterFromCache.exclude = [ /main\.js$/ ]
       builder = new broccoli.Builder(tree);
       return builder.build().then(function() {
         expect(listFiles).to.eql(['tests/fixtures/sample-project/core.js']);
+        expect(listFiles.length).to.equal(1)
+      });
+    });
+
+    it('returns an array of files keyed both include & exclude filters', function() {
+      tree.filterFromCache.include = [ /\.js$/ ]
+      tree.filterFromCache.exclude = [ /core\.js$/ ]
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function() {
+        expect(listFiles).to.eql(['tests/fixtures/sample-project/main.js']);
         expect(listFiles.length).to.equal(1)
       });
     });


### PR DESCRIPTION
When extending the CachingWriter I have found I often end up having to duplicate the include/exclude logic which feels pretty sub optimal and error prone.

The following safely exposes any files used in the lastKeys check which I think is the cleanest way of getting at the information.