### PR TITLE
Fix operator precedence issue when comparing keys

### DIFF
--- a/key.js
+++ b/key.js
@@ -61,7 +61,7 @@ Key.prototype.equal = function(otherKey) {
       this.path       === otherKey.path &&
       this.stat.mode  === otherKey.stat.mode &&
       this.stat.size  === otherKey.stat.size &&
-      this.type === 'directory' ? true : this.stat.mtime.getTime() === otherKey.stat.mtime.getTime()) {
+      (this.type === 'directory' ? true : this.stat.mtime.getTime() === otherKey.stat.mtime.getTime())) {
     return true;
   } else {
     logNotEqual(this, otherKey);


### PR DESCRIPTION
Noticed this when a filter was not invalidating its cache when a file was renamed (different name, same mtime and content): 

![](https://s3.amazonaws.com/f.cl.ly/items/3e3v1i0a3a3x10331X2r/Screen%20Shot%202015-05-14%20at%2010.58.23%20AM.png)

Smaller expression of the issue:

```
> true === false && true ? 'ternary is true' : 'ternary is false, shouldn't get here'
'ternary is false, shouldn't get here'
> true === false && (true ? 'ternary is true' : 'ternary is false')
false
```

/cc @stefanpenner @rwjblue 