### PR TITLE
Make CachingWriter a drop-in replacement for Plugin

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules
+tests/fixtures

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,3 @@
 node_modules
 tests/fixtures
+tmp

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "node": true,
+  "undef": true,
+  "eqnull": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Remove `enforceSingleInputTree` option; we now always expect an array
+
 ## 1.0.0
 
 * Bump without changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ## master
 
-* Derive from broccoli-plugin base class; stop deriving from CoreObject
+* Derive from broccoli-plugin base class, and expose same interface. In particular:
+
+    * `updateCache(srcDirs, destDir)` becomes `build()`
+    * We no longer derive from CoreObject
+    * We gain the `name`, `annotation`, and `persistentOutput` options
+    * `options` no longer auto-assigns to `this`; unknown options are ignored
+    * `filterFromCache` must be passed in through `options`, and cannot be set on
+      the prototype/instance
+
 * Remove `enforceSingleInputTree` option; we now always expect an array
 
 ## 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 
+* Derive from broccoli-plugin base class; stop deriving from CoreObject
 * Remove `enforceSingleInputTree` option; we now always expect an array
 
 ## 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
     * We no longer derive from CoreObject
     * We gain the `name`, `annotation`, and `persistentOutput` options
     * `options` no longer auto-assigns to `this`; unknown options are ignored
-    * `filterFromCache` must be passed in through `options`, and cannot be set on
-      the prototype/instance
+
+* `filterFromCache.include`/`filterFromCache.exclude` are now called
+  `cacheInclude`/`cacheExclude`; they must now be passed in through
+  `options`, and can no longer be set on the prototype/instance
 
 * Remove `enforceSingleInputTree` option; we now always expect an array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## master
+
+## 1.0.0
+
+* Bump without changes
+
+## 0.6.2
+
+* Improve logging
+
+## 0.6.1
+
+* Ignore changes in directory size/mtime, so that excluded files can be added
+  or removed without causing invalidations
+
+## 0.6.0
+
 * Use new [`.rebuild` API](https://github.com/broccolijs/broccoli/blob/master/docs/new-rebuild-api.md)
 
 ## 0.5.5
@@ -71,7 +88,7 @@ var outputTree = compileCompass(inputTree, {
   (for those curious stay tuned on Windows support [here](https://github.com/broccolijs/node-symlink-or-copy/pull/1)).
 
 * Allow multiple input trees. If an array of trees is passed to the constructor, all trees will be read and their collective
-  output will be used to calculate the cache (any trees invalidating causes `updateCache` to be called). 
+  output will be used to calculate the cache (any trees invalidating causes `updateCache` to be called).
 
   The default now is to assume that an array of trees is allowed, if you want to opt-out of this behavior set `enforceSingleInputTree`
   to `true` on your classes prototype.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Call this base class constructor from your subclass constructor.
       [broccoli-plugin](https://github.com/broccolijs/broccoli-plugin#new-plugininputnodes-options);
       see there.
 
-    * `filterFromCache.include` (default: `[]`): An array of regular expressions that files and directories in an input node must pass (match at least one pattern) in order to be included in the cache hash for rebuilds. In other words, a whitelist of patterns that identify which files and/or directories can trigger a rebuild.
+    * `cacheInclude` (default: `[]`): An array of regular expressions that files and directories in an input node must pass (match at least one pattern) in order to be included in the cache hash for rebuilds. In other words, a whitelist of patterns that identify which files and/or directories can trigger a rebuild.
 
-    * `filterFromCache.exclude` (default: `[]`): An array of regular expressions that files and directories in an input node cannot pass in order to be included in the cache hash for rebuilds. In other words, a blacklist of patterns that identify which files and/or directories will never trigger a rebuild.
+    * `cacheExclude` (default: `[]`): An array of regular expressions that files and directories in an input node cannot pass in order to be included in the cache hash for rebuilds. In other words, a blacklist of patterns that identify which files and/or directories will never trigger a rebuild.
 
         *Note, in the case when a file or directory matches both an include and exlude pattern, the exclude pattern wins*
 

--- a/README.md
+++ b/README.md
@@ -3,86 +3,65 @@
 [![Build Status](https://travis-ci.org/ember-cli/broccoli-caching-writer.svg?branch=master)](https://travis-ci.org/ember-cli/broccoli-caching-writer)
 [![Build status][appveyor-badge]][appveyor-badge-url]
 
-Adds a thin caching layer based on the computed hash of the input tree. If the input tree has changed,
-the `updateCache` method will be called, otherwise (input is the same) the results of the last `updateCache`
-call will be used instead.
+Drop-in-replacement for
+[broccoli-plugin](https://github.com/broccolijs/broccoli-plugin) adding a thin
+caching layer based on the computed hash of the input directory trees. If any
+file in an input node has changed, the `build` method will be called,
+otherwise (if input is the same) the results of the last `build` call will be
+used instead.
 
-If you would prefer to perform your plugins work in a non-synchronous way, simply return a promise from `updateCache`.
+## Example
+
+Say your plugin derives from `Plugin` like so:
+
+```js
+var Plugin = require('broccoli-plugin');
+
+MyPlugin.prototype = Object.create(Plugin.prototype);
+MyPlugin.prototype.constructor = MyPlugin;
+function MyPlugin(inputNodes, options) {
+  options = options || {};
+  Plugin.call(this, inputNodes, {
+    annotation: options.annotation
+  });
+}
+```
+
+To add caching, simply replace `Plugin` with `CachingWriter`, like so:
+
+```js
+var CachingWriter = require('broccoli-caching-writer');
+
+MyPlugin.prototype = Object.create(CachingWriter.prototype);
+MyPlugin.prototype.constructor = MyPlugin;
+function MyPlugin(inputNodes, options) {
+  options = options || {};
+  CachingWriter.call(this, inputNodes, {
+    annotation: options.annotation
+  });
+}
+```
+
 
 ## Documentation
 
-### `new CachingWriter(inputTrees, options)`
+### `new CachingWriter(inputNodes, options)`
 
-`inputTrees` *{Array of Trees}*
+Call this base class constructor from your subclass constructor.
 
-An array of input trees.
+* `inputNodes`: An array of input nodes.
 
-#### Options
+* `options`:
 
-`filterFromCache.include` *{Array of RegExps}*
+    * `name`, `annotation`, `persistentOutput`: Same as
+      [broccoli-plugin](https://github.com/broccolijs/broccoli-plugin#new-plugininputnodes-options);
+      see there.
 
-An array of regular expressions that files and directories in the input tree must pass (match at least one pattern) in order to be included in the cache hash for rebuilds. In other words, a whitelist of patterns that identify which files and/or directories can trigger a rebuild.
+    * `filterFromCache.include` (default: `[]`): An array of regular expressions that files and directories in an input node must pass (match at least one pattern) in order to be included in the cache hash for rebuilds. In other words, a whitelist of patterns that identify which files and/or directories can trigger a rebuild.
 
+    * `filterFromCache.exclude` (default: `[]`): An array of regular expressions that files and directories in an input node cannot pass in order to be included in the cache hash for rebuilds. In other words, a blacklist of patterns that identify which files and/or directories will never trigger a rebuild.
 
-Default: `[]`
-
-----
-
-`filterFromCache.exclude` *{Array of RegExps}*
-
-An array of regular expressions that files and directories in the input tree cannot pass in order to be included in the cache hash for rebuilds. In other words, a blacklist of patterns that identify which files and/or directories will never trigger a rebuild.
-
-*Note, in the case when a file or directory matches both an include and exlude pattern, the exclude pattern wins*
-
-Default: `[]`
-
-
-## Switching from `broccoli-writer`
-
-If your broccoli plugin currently extends `broccoli-writer`,
-and you wish to extend `broccoli-caching-writer` instead:
-
-1. Switch the constructor
-  - Require this module: `var CachingWriter  = require('broccoli-caching-writer');`
-  - Change the prototype to use `CachingWriter`: `MyBroccoliWriter.prototype = Object.create(CachingWriter.prototype);`
-  - In the constructor, ensure that you are calling `CachingWriter.apply(this, arguments);`.
-2. Switch `write` function for an `updateCache` function.
-  - Switch the function signatures:
-    - From: `MyBroccoliWriter.prototype.write = function(readTree, destDir) {`
-    - To: `MyBroccoliWriter.prototype.updateCache = function(srcDir, destDir) {`
-  - Get rid of `readTree`, as `srcPaths` (array of paths from input trees) is already provided:
-    - Code that looks like: `return readTree(this.inputTree).then(function (srcPaths) { /* Do the main processing */ });`
-    - Simply extract the code, `/* Do the main processing */`, and get rid of the function wrapping it.
-
-## Inheritance
-
-broccoli-caching-writer inherits from [core-object](https://github.com/stefanpenner/core-object) to allow super simple
-inheritance. You can still absolutely use the standard prototypal inheritance, but as you can see below there may be no
-need.
-
-Make an `index.js` for your package:
-
-```javascript
-var CachingWriter = require('broccoli-caching-writer');
-
-module.exports = CachingWriter.extend({
-  init: function(inputTrees, options) {
-    /* do additional setup here */
-  },
-
-  updateCache: function(srcPaths, destDir) {
-    /* do main processing */
-  }
-});
-```
-
-Then in a consuming Brocfile:
-
-```javascript
-var MyFoo = require('my-foo'); // package from above
-
-var tree = new MyFoo([someInput], { some: 'options' });
-```
+        *Note, in the case when a file or directory matches both an include and exlude pattern, the exclude pattern wins*
 
 
 ## ZOMG!!! TESTS?!?!!?

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ If you would prefer to perform your plugins work in a non-synchronous way, simpl
 
 ### `new CachingWriter(inputTrees, options)`
 
-`inputTrees` *{Array of Trees | Single Tree}*
+`inputTrees` *{Array of Trees}*
 
-Can either be a single tree, or an array of trees. If an array was specified, an array of source paths will be provided when
-calling `updateCache`.
+An array of input trees.
 
 #### Options
 

--- a/index.js
+++ b/index.js
@@ -210,20 +210,20 @@ CachingWriter.keyForTree = function (fullPath, initialRelativePath, dir) {
 CachingWriter.listFiles = function() {
   function listFiles(keys, files) {
     for (var i=0; i< keys.length; i++) {
-      var key = keys[i]
+      var key = keys[i];
       if (key.type === 'file') {
-        files.push(key.fullPath)
+        files.push(key.fullPath);
       } else {
         var children = key.children;
         if(children && children.length > 0) {
-          listFiles(children, files)
+          listFiles(children, files);
         }
       }
     }
-    return files
+    return files;
   }
-  return listFiles(this._lastKeys, [])
-}
+  return listFiles(this._lastKeys, []);
+};
 
 var CachingWriterClass = CoreObject.extend(CachingWriter);
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function CachingWriter (inputNodes, options) {
   this._resetStats();
 
   this._filterFromCache = options.filterFromCache || {};
+  this._inputFiles = options.inputFiles || {};
 
   if (this._filterFromCache.include === undefined) {
     this._filterFromCache.include = [];
@@ -181,8 +182,8 @@ CachingWriter.prototype.keyForTree = function (fullPath, initialRelativePath, di
       console.warn(err.stack);
     }
 
-    if (canUseInputFiles(this.inputFiles)) {
-      children = this.inputFiles.map(function(file) {
+    if (canUseInputFiles(this._inputFiles)) {
+      children = this._inputFiles.map(function(file) {
         return this.keyForTree(
           path.join(dir, file),
           file,

--- a/index.js
+++ b/index.js
@@ -27,19 +27,10 @@ CachingWriter.init = function(inputTrees, options) {
     }
   }
 
-  if (!inputTrees) {
-    throw new Error('no inputTree was provided');
+  if (!Array.isArray(inputTrees)) {
+    throw new Error('Expected an array of inputTrees, got ' + inputTrees);
   }
-
-  if (Array.isArray(inputTrees)) {
-    if (this.enforceSingleInputTree) {
-      throw new Error('You passed an array of input trees, but only a single tree is allowed.');
-    }
-
-    this.inputTrees = inputTrees;
-  } else {
-    this.inputTrees = [inputTrees];
-  }
+  this.inputTrees = inputTrees;
 
   if (this.filterFromCache === undefined) {
     this.filterFromCache = {};
@@ -61,8 +52,6 @@ CachingWriter.init = function(inputTrees, options) {
     throw new Error('Invalid filterFromCache.exclude option, it must be an array or undefined.');
   }
 };
-
-CachingWriter.enforceSingleInputTree = false;
 
 CachingWriter.debug = function() {
   return this._debug || (this._debug = debugGenerator('broccoli-caching-writer:' + (this.constructorDescription || this.constructor.name) + ' > [' + this.description + ']'));
@@ -98,13 +87,11 @@ CachingWriter.rebuild = function () {
   this._resetStats();
 
   if (invalidateCache) {
-    var updateCacheSrcArg = writer.enforceSingleInputTree ? writer.inputPaths[0] : writer.inputPaths;
-
     writer._lastKeys = lastKeys;
 
     updateCacheResult = rimraf(writer.cachePath).then(function () {
       fs.mkdirSync(writer.cachePath);
-      return writer.updateCache(updateCacheSrcArg, writer.cachePath);
+      return writer.updateCache(writer.inputPaths, writer.cachePath);
     });
 
   }
@@ -115,7 +102,7 @@ CachingWriter.rebuild = function () {
   });
 };
 
-CachingWriter.updateCache = function (srcDir, destDir) {
+CachingWriter.updateCache = function (srcDirs, destDir) {
   throw new Error('You must implement updateCache.');
 };
 

--- a/index.js
+++ b/index.js
@@ -29,23 +29,16 @@ function CachingWriter (inputNodes, options) {
   this._shouldBeIgnoredCache = Object.create(null);
   this._resetStats();
 
-  this._filterFromCache = options.filterFromCache || {};
+  this._cacheInclude = options.cacheInclude || [];
+  this._cacheExclude = options.cacheExclude || [];
   this._inputFiles = options.inputFiles || {};
 
-  if (this._filterFromCache.include === undefined) {
-    this._filterFromCache.include = [];
+  if (!Array.isArray(this._cacheInclude)) {
+    throw new Error('Invalid cacheInclude option, it must be an array or undefined.');
   }
 
-  if (this._filterFromCache.exclude === undefined) {
-    this._filterFromCache.exclude = [];
-  }
-
-  if (!Array.isArray(this._filterFromCache.include)) {
-    throw new Error('Invalid filterFromCache.include option, it must be an array or undefined.');
-  }
-
-  if (!Array.isArray(this._filterFromCache.exclude)) {
-    throw new Error('Invalid filterFromCache.exclude option, it must be an array or undefined.');
+  if (!Array.isArray(this._cacheExclude)) {
+    throw new Error('Invalid cacheExclude option, it must be an array or undefined.');
   }
 }
 
@@ -122,8 +115,8 @@ CachingWriter.prototype.shouldBeIgnored = function (fullPath) {
     return this._shouldBeIgnoredCache[fullPath];
   }
 
-  var excludePatterns = this._filterFromCache.exclude;
-  var includePatterns = this._filterFromCache.include;
+  var excludePatterns = this._cacheExclude;
+  var includePatterns = this._cacheInclude;
   var i = null;
 
   // Check exclude patterns

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "symlink-or-copy": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "~1.18.2",
     "broccoli": "^0.13.0",
-    "expect.js": "^0.3.1"
+    "expect.js": "^0.3.1",
+    "mocha": "^2.2.5",
+    "mocha-jshint": "~2.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.2.5",
-    "broccoli-plugin": "^1.0.0",
+    "broccoli-plugin": "1.1.0",
     "debug": "^2.1.1",
     "lodash-node": "^3.2.0",
     "rimraf": "^2.2.8",
@@ -28,7 +28,8 @@
   },
   "devDependencies": {
     "broccoli": "^0.13.0",
-    "expect.js": "^0.3.1",
+    "chai": "^3.2.0",
+    "chai-as-promised": "^5.1.0",
     "mocha": "^2.2.5",
     "mocha-jshint": "~2.2.3"
   }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   ],
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.2.5",
-    "broccoli-read-compat": "^0.1.3",
-    "core-object": "^1.1.0",
+    "broccoli-plugin": "^1.0.0",
     "debug": "^2.1.1",
     "lodash-node": "^3.2.0",
     "rimraf": "^2.2.8",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "extends": "../.jshintrc",
+  "mocha": true,
+  "expr": true
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,7 +14,7 @@ var CachingWriter = require('..');
 
 var builder;
 
-describe('broccoli-caching-writer', function(){
+describe('broccoli-caching-writer', function() {
   var sourcePath = 'tests/fixtures/sample-project';
   var secondaryPath = 'tests/fixtures/other-tree';
 
@@ -404,7 +404,7 @@ describe('broccoli-caching-writer', function(){
       tree = new CachingWriter([sourcePath]);
       tree.updateCache = function(srcDir, destDir){
         listFiles = this.listFiles();
-      }
+      };
     });
 
     it('returns an array of files keyed', function() {
@@ -414,37 +414,37 @@ describe('broccoli-caching-writer', function(){
           path.normalize('tests/fixtures/sample-project/core.js'),
           path.normalize('tests/fixtures/sample-project/main.js')
         ]);
-        expect(listFiles.length).to.equal(2)
+        expect(listFiles.length).to.equal(2);
       });
     });
 
     it('returns an array of files keyed including only those in the include filter', function() {
-      tree.filterFromCache.include = [ /core\.js$/ ]
+      tree.filterFromCache.include = [ /core\.js$/ ];
       builder = new broccoli.Builder(tree);
 
       return builder.build().then(function() {
         expect(listFiles).to.eql([
           path.normalize('tests/fixtures/sample-project/core.js')
         ]);
-        expect(listFiles.length).to.equal(1)
+        expect(listFiles.length).to.equal(1);
       });
     });
 
     it('returns an array of files keyed ignoring those in the exclude filter', function() {
-      tree.filterFromCache.exclude = [ /main\.js$/ ]
+      tree.filterFromCache.exclude = [ /main\.js$/ ];
       builder = new broccoli.Builder(tree);
 
       return builder.build().then(function() {
         expect(listFiles).to.eql([
           path.normalize('tests/fixtures/sample-project/core.js')
         ]);
-        expect(listFiles.length).to.equal(1)
+        expect(listFiles.length).to.equal(1);
       });
     });
 
     it('returns an array of files keyed both include & exclude filters', function() {
-      tree.filterFromCache.include = [ /\.js$/ ]
-      tree.filterFromCache.exclude = [ /core\.js$/ ]
+      tree.filterFromCache.include = [ /\.js$/ ];
+      tree.filterFromCache.exclude = [ /core\.js$/ ];
 
       builder = new broccoli.Builder(tree);
 
@@ -452,10 +452,10 @@ describe('broccoli-caching-writer', function(){
         expect(listFiles).to.eql([
           path.normalize('tests/fixtures/sample-project/main.js')
         ]);
-        expect(listFiles.length).to.equal(1)
+        expect(listFiles.length).to.equal(1);
       });
     });
-  })
+  });
 });
 
 var canUseInputFiles = require('../can-use-input-files');

--- a/tests/index.js
+++ b/tests/index.js
@@ -102,11 +102,9 @@ describe('broccoli-caching-writer', function() {
         .then(expectNoRebuild());
     });
 
-    it('does not call build again if input is changed but filtered from cache (via exclude)', function() {
+    it('does not call build again if input is changed but filtered from cache (via cacheExclude)', function() {
       setupCachingWriter([sourcePath], {
-        filterFromCache: {
-          exclude: [/.*\.txt$/]
-        }
+        cacheExclude: [/.*\.txt$/]
       });
 
       return expectRebuild()
@@ -114,11 +112,9 @@ describe('broccoli-caching-writer', function() {
         .then(expectNoRebuild);
     });
 
-    it('does not call updateCache again if input is changed but filtered from cache (via include)', function() {
+    it('does not call updateCache again if input is changed but filtered from cache (via cacheInclude)', function() {
       setupCachingWriter([sourcePath], {
-        filterFromCache: {
-          include: [/.*\.js$/]
-        }
+        cacheInclude: [/.*\.js$/]
       });
 
       return expectRebuild()
@@ -128,9 +124,7 @@ describe('broccoli-caching-writer', function() {
 
     it('does call build again if input is changed is included in the cache filter', function() {
       setupCachingWriter([sourcePath], {
-        filterFromCache: {
-          include: [/.*\.js$/]
-        }
+        cacheInclude: [/.*\.js$/]
       });
 
       return expectRebuild()
@@ -233,9 +227,9 @@ describe('broccoli-caching-writer', function() {
 
   describe('shouldBeIgnored', function() {
     it('returns true if the path is included in an exclude filter', function() {
-      var node = new CachingWriter([sourcePath], { filterFromCache: {
-        exclude: [ /.foo$/, /.bar$/ ]
-      }});
+      var node = new CachingWriter([sourcePath], {
+        cacheExclude: [ /.foo$/, /.bar$/ ]
+      });
 
       expect(node.shouldBeIgnored('blah/blah/blah.foo')).to.be.ok;
       expect(node.shouldBeIgnored('blah/blah/blah.bar')).to.be.ok;
@@ -243,18 +237,18 @@ describe('broccoli-caching-writer', function() {
     });
 
     it('returns false if the path is included in an include filter', function() {
-      var node = new CachingWriter([sourcePath], { filterFromCache: {
-        include: [ /.foo$/, /.bar$/ ]
-      }});
+      var node = new CachingWriter([sourcePath], {
+        cacheInclude: [ /.foo$/, /.bar$/ ]
+      });
 
       expect(node.shouldBeIgnored('blah/blah/blah.foo')).to.not.be.ok;
       expect(node.shouldBeIgnored('blah/blah/blah.bar')).to.not.be.ok;
     });
 
     it('returns true if the path is not included in an include filter', function() {
-      var node = new CachingWriter([sourcePath], { filterFromCache: {
-        include: [ /.foo$/, /.bar$/ ]
-      }});
+      var node = new CachingWriter([sourcePath], {
+        cacheInclude: [ /.foo$/, /.bar$/ ]
+      });
 
       expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.be.ok;
     });
@@ -272,7 +266,7 @@ describe('broccoli-caching-writer', function() {
 
       // changing the filter mid-run should have no result on
       // previously calculated paths
-      node._filterFromCache.include = [ /.foo$/, /.bar$/ ];
+      node._cacheInclude = [ /.foo$/, /.bar$/ ];
 
       expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok;
     });
@@ -281,8 +275,8 @@ describe('broccoli-caching-writer', function() {
   describe('listFiles', function() {
     var listFiles;
 
-    function getListFilesFor(filterFromCache) {
-      setupCachingWriter([sourcePath], { filterFromCache: filterFromCache }, function() {
+    function getListFilesFor(options) {
+      setupCachingWriter([sourcePath], options, function() {
         var writer = this;
         listFiles = this.listFiles().map(function(p) {
           return path.relative(writer.inputPaths[0], p);
@@ -299,20 +293,20 @@ describe('broccoli-caching-writer', function() {
 
     it('returns an array of files keyed including only those in the include filter', function() {
       return expect(getListFilesFor({
-        include: [ /core\.js$/ ]
+        cacheInclude: [ /core\.js$/ ]
       })).to.eventually.deep.equal(['core.js']);
     });
 
     it('returns an array of files keyed ignoring those in the exclude filter', function() {
       return expect(getListFilesFor({
-        exclude: [ /main\.js$/ ]
+        cacheExclude: [ /main\.js$/ ]
       })).to.eventually.deep.equal(['core.js']);
     });
 
     it('returns an array of files keyed both include & exclude filters', function() {
       return expect(getListFilesFor({
-        include: [ /\.js$/ ],
-        exclude: [ /core\.js$/ ]
+        cacheInclude: [ /\.js$/ ],
+        cacheExclude: [ /core\.js$/ ]
       })).to.eventually.deep.equal(['main.js']);
     });
   });

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,18 +1,52 @@
-/* jshint node: true */
-/* global it: true, describe: true, afterEach, beforeEach */
-
 'use strict';
 
 var fs = require('fs');
 var path = require('path');
-var expect = require('expect.js');
-var RSVP = require('rsvp');
-var rimraf = require('rimraf');
-var root = process.cwd();
+var chai = require('chai'), expect = chai.expect;
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
 var broccoli = require('broccoli');
 var CachingWriter = require('..');
 
-var builder;
+var builder, cachingWriter, buildCount;
+
+function setupCachingWriter(inputNodes, options, buildCallback) {
+  if (!buildCallback) buildCallback = function() { };
+  buildCount = 0;
+  cachingWriter = new CachingWriter(inputNodes, options);
+  cachingWriter.build = function() {
+    buildCount++;
+    return buildCallback.call(this);
+  };
+  builder = new broccoli.Builder(cachingWriter);
+}
+
+function build(expectRebuild) {
+  return builder.build()
+    .then(function(hash) {
+      return hash.directory;
+    });
+}
+
+function expectRebuild() {
+  var oldBuildCount = buildCount;
+  return build()
+    .then(function(outputPath) { // cannot use finally - expect failure would override previous error
+      expect(buildCount).to.equal(oldBuildCount + 1,
+        'expected rebuild to be triggered');
+      return outputPath;
+    });
+}
+
+function expectNoRebuild() {
+  var oldBuildCount = buildCount;
+  return build()
+    .then(function(outputPath) { // cannot use finally - expect failure would override previous error
+      expect(buildCount).to.equal(oldBuildCount,
+        'expected rebuild not to be triggered');
+      return outputPath;
+    });
+}
 
 describe('broccoli-caching-writer', function() {
   var sourcePath = 'tests/fixtures/sample-project';
@@ -36,381 +70,250 @@ describe('broccoli-caching-writer', function() {
     }
   });
 
-  function build() {
-    return builder.build();
-  }
+  describe('cache invalidation', function() {
+    it('calls build once at the beginning, and again only when input is changed', function() {
+      setupCachingWriter([sourcePath, secondaryPath], {});
 
-  function buildInSeries(count) {
-    var promise = RSVP.Promise.resolve();
-
-    for (var i = 0; i < count; i++) {
-      promise = promise.then(build);
-    }
-
-    return promise;
-  }
-
-  describe('write', function() {
-    it('calls updateCache when there is no cache', function(){
-      var updateCacheCalled = false;
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function() {
-          updateCacheCalled = true;
-        }
-      });
-
-      builder = new broccoli.Builder(tree);
-
-      return builder.build().finally(function() {
-        expect(updateCacheCalled).to.be.ok();
-      });
+      return expectRebuild()
+        .then(expectNoRebuild)
+        .then(expectNoRebuild)
+        .then(function() { fs.writeFileSync(dummyChangedFile, 'bergh'); })
+        .then(expectRebuild)
+        .then(expectNoRebuild)
+        .then(function() { fs.writeFileSync(secondaryPath + '/foo-baz.js', 'bergh'); })
+        .then(expectRebuild)
+        .then(expectNoRebuild);
     });
 
-    it('is provided a source and destination directory', function(){
-      var updateCacheCalled = false;
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function(srcDirs, destDir) {
-          expect(fs.statSync(srcDirs[0]).isDirectory()).to.be.ok();
-          expect(fs.statSync(destDir).isDirectory()).to.be.ok();
-        }
-      });
+    it('calls build again if existing file is changed', function() {
+      setupCachingWriter([sourcePath], {});
 
-      builder = new broccoli.Builder(tree);
-      return builder.build();
+      return expectRebuild()
+        .then(function() { fs.writeFileSync(existingJSFile, '"YIPPIE"\n"KI-YAY!"\n'); })
+        .then(expectRebuild)
+        .then(expectNoRebuild)
+        .finally(function() { fs.writeFileSync(existingJSFile, '"YIPPIE"\n'); });
     });
 
-    it('only calls updateCache once if input is not changing', function(){
-      var updateCacheCount = 0;
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function() {
-          updateCacheCount++;
-        }
-      });
+    it('builds once with no input nodes', function() {
+      setupCachingWriter([], {});
 
-      builder = new broccoli.Builder(tree);
-
-      return buildInSeries(3)
-        .then(function() {
-          expect(updateCacheCount).to.equal(1);
-        });
+      return expectRebuild()
+        .then(expectNoRebuild());
     });
 
-    it('calls updateCache again if input is changed', function(){
-      var updateCacheCount = 0;
-
-      var tree = new CachingWriter([sourcePath, secondaryPath], {
-        updateCache: function() {
-          updateCacheCount++;
-        }
-      });
-
-      builder = new broccoli.Builder(tree);
-
-      return builder.build()
-        .finally(function() {
-          expect(updateCacheCount).to.equal(1);
-        })
-        .then(function() {
-          fs.writeFileSync(dummyChangedFile, 'bergh');
-
-          return buildInSeries(3);
-        })
-        .finally(function() {
-          expect(updateCacheCount).to.equal(2);
-        })
-        .then(function() {
-          fs.writeFileSync(secondaryPath + '/foo-baz.js', 'bergh');
-
-          return buildInSeries(3);
-        })
-        .finally(function() {
-          expect(updateCacheCount).to.equal(3);
-        });
-    });
-
-    it('calls updateCache again if existing file is changed', function(){
-      var updateCacheCount = 0;
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function() {
-          updateCacheCount++;
-        }
-      });
-
-      builder = new broccoli.Builder(tree);
-
-      return builder.build()
-        .finally(function() {
-          expect(updateCacheCount).to.equal(1);
-        })
-        .then(function() {
-          fs.writeFileSync(existingJSFile, '"YIPPIE"\n"KI-YAY!"\n');
-
-          return buildInSeries(3);
-        })
-        .finally(function() {
-          fs.writeFileSync(existingJSFile, '"YIPPIE"\n');
-          expect(updateCacheCount).to.equal(2);
-        });
-    });
-
-    it('does not call updateCache again if input is changed but filtered from cache (via exclude)', function(){
-      var updateCacheCount = 0;
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function() {
-          updateCacheCount++;
-        },
+    it('does not call build again if input is changed but filtered from cache (via exclude)', function() {
+      setupCachingWriter([sourcePath], {
         filterFromCache: {
           exclude: [/.*\.txt$/]
         }
       });
 
-      builder = new broccoli.Builder(tree);
-
-      return builder.build()
-        .finally(function() {
-          expect(updateCacheCount).to.equal(1);
-        })
-        .then(function() {
-          fs.writeFileSync(dummyChangedFile, 'bergh');
-
-          return buildInSeries(3);
-        })
-        .finally(function() {
-          expect(updateCacheCount).to.equal(1);
-        });
+      return expectRebuild()
+        .then(function() { fs.writeFileSync(dummyChangedFile, 'bergh'); })
+        .then(expectNoRebuild);
     });
 
-    it('does not call updateCache again if input is changed but filtered from cache (via include)', function(){
-      var updateCacheCount = 0;
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function() {
-          updateCacheCount++;
-        },
+    it('does not call updateCache again if input is changed but filtered from cache (via include)', function() {
+      setupCachingWriter([sourcePath], {
         filterFromCache: {
           include: [/.*\.js$/]
         }
       });
 
-      builder = new broccoli.Builder(tree);
-
-      return builder.build()
-        .finally(function() {
-          expect(updateCacheCount).to.equal(1);
-        })
-        .then(function() {
-          fs.writeFileSync(dummyChangedFile, 'bergh');
-
-          return buildInSeries(4);
-        })
-        .finally(function() {
-          expect(updateCacheCount).to.equal(1);
-        });
+      return expectRebuild()
+        .then(function() { fs.writeFileSync(dummyChangedFile, 'bergh'); })
+        .then(expectNoRebuild);
     });
 
-    it('does call updateCache again if input is changed is included in the cache filter', function(){
-      var updateCacheCount = 0;
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function() {
-          updateCacheCount++;
-        },
+    it('does call build again if input is changed is included in the cache filter', function() {
+      setupCachingWriter([sourcePath], {
         filterFromCache: {
           include: [/.*\.js$/]
         }
       });
 
-      builder = new broccoli.Builder(tree);
-
-      return builder.build()
-        .finally(function() {
-          expect(updateCacheCount).to.equal(1);
-        })
-        .then(function() {
-          fs.writeFileSync(dummyJSChangedFile, 'bergh');
-
-          return buildInSeries(3);
-        })
-        .finally(function() {
-          expect(updateCacheCount).to.equal(2);
-        });
+      return expectRebuild()
+        .then(function() { fs.writeFileSync(dummyJSChangedFile, 'bergh'); })
+        .then(expectRebuild);
     });
   });
 
-  describe('updateCache', function() {
-    it('provides array of paths if array of sourceTrees was provided', function() {
-      var tree = new CachingWriter([sourcePath, secondaryPath], {
-        updateCache: function(srcDirs, destDir) {
-          expect(fs.readFileSync(srcDirs[0] + '/core.js', {
-            encoding: 'utf8'
-          })).to.contain('"YIPPIE"');
-          expect(fs.readFileSync(srcDirs[1] + '/bar.js', {
-            encoding: 'utf8'
-          })).to.contain('"BLAMMO!"');
-
-          fs.writeFileSync(destDir + '/something-cool.js', 'zomg blammo', {
-            encoding: 'utf8'
-          });
-        }
-      });
-
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function(result) {
-        var dir = result.directory;
-
-        expect(fs.readFileSync(dir + '/something-cool.js', {
+  describe('build', function() {
+    it('can read from inputPaths', function() {
+      setupCachingWriter([sourcePath, secondaryPath], {}, function() {
+        expect(fs.readFileSync(this.inputPaths[0] + '/core.js', {
           encoding: 'utf8'
-        })).to.equal('zomg blammo');
+        })).to.contain('"YIPPIE"');
+        expect(fs.readFileSync(this.inputPaths[1] + '/bar.js', {
+          encoding: 'utf8'
+        })).to.contain('"BLAMMO!"');
       });
+
+      return expectRebuild();
     });
 
-    it('can write files to destDir, and they will be in the final output', function(){
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function(srcDir, destDir) {
-          fs.writeFileSync(destDir + '/something-cool.js', 'zomg blammo', {encoding: 'utf8'});
-        }
+    it('can write to outputPath', function() {
+      setupCachingWriter([sourcePath], {}, function() {
+        fs.writeFileSync(this.outputPath + '/something-cool.js', 'zomg blammo', {encoding: 'utf8'});
       });
 
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function(result) {
-        var dir = result.directory;
-        expect(fs.readFileSync(dir + '/something-cool.js', {
-          encoding: 'utf8'
-        })).to.equal('zomg blammo');
-      });
+      return expectRebuild()
+        .then(function(outputPath) {
+          expect(fs.readFileSync(outputPath + '/something-cool.js', {
+            encoding: 'utf8'
+          })).to.equal('zomg blammo');
+        });
     });
 
     it('throws an error if not overriden', function(){
-      var tree = new CachingWriter([sourcePath]);
+      setupCachingWriter([sourcePath], {});
+      delete cachingWriter.build;
 
-      builder = new broccoli.Builder(tree);
-      return builder.build()
-        .catch(function(reason) {
-          expect(reason.message).to.equal('You must implement updateCache.');
-        });
+      return expect(build()).to.be.rejectedWith(/Plugin subclasses must implement/);
     });
 
     it('can return a promise that is resolved', function(){
       var thenCalled = false;
-      var tree = new CachingWriter([sourcePath], {
-        updateCache: function(srcDir, destDir) {
-          return {then: function(callback) {
-            thenCalled = true;
-            callback();
-          }};
-        }
+      setupCachingWriter([sourcePath], {}, function() {
+        return {then: function(callback) {
+          thenCalled = true;
+          callback();
+        }};
       });
 
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function() {
-        expect(thenCalled).to.be.ok();
+      return expectRebuild().then(function() {
+        expect(thenCalled).to.be.ok;
       });
     });
   });
 
-  describe('arguments', function() {
-    it('throws exception when no input tree is provided', function() {
+  describe('constructor', function() {
+    it('throws exception when no input nodes are provided', function() {
       expect(function() {
         new CachingWriter();
-      }).to.throwException(/Expected an array/);
+      }).to.throw(/Expected an array/);
     });
 
     it('throws exception when something other than an array is passed', function() {
       expect(function() {
-        var tree = new CachingWriter('not/an/array', {
-          updateCache: function() { }
+        new CachingWriter('not/an/array');
+      }).to.throw(/Expected an array/);
+    });
+  });
+
+  describe('persistentOutput behavior mimics broccoli-plugin', function() {
+    function buildOnce() {
+      /*jshint validthis:true */
+      if (!this.builtOnce) {
+        this.builtOnce = true;
+        fs.writeFileSync(path.join(this.outputPath, 'foo.txt'), 'yay');
+      }
+    }
+
+    function isEmptied() {
+      return expectRebuild()
+        .then(function() { fs.writeFileSync(dummyChangedFile, 'force rebuild'); })
+        .then(expectRebuild)
+        .then(function(outputPath) {
+          return !fs.existsSync(path.join(outputPath, 'foo.txt'));
         });
-      }).throwException(/Expected an array/);
+    }
+
+    it('empties the output directory by default', function() {
+      setupCachingWriter([sourcePath], {}, buildOnce);
+      return expect(isEmptied()).to.be.eventually.true;
+    });
+
+    it('does not empty the output directory if persistentOutput is true', function() {
+      setupCachingWriter([sourcePath], { persistentOutput: true }, buildOnce);
+      return expect(isEmptied()).to.be.eventually.false;
     });
   });
 
   describe('shouldBeIgnored', function() {
-    var tree;
-
-    beforeEach(function() {
-      tree = new CachingWriter([sourcePath]);
-    });
-
     it('returns true if the path is included in an exclude filter', function() {
-      tree.filterFromCache.exclude = [ /.foo$/, /.bar$/ ];
+      var node = new CachingWriter([sourcePath], { filterFromCache: {
+        exclude: [ /.foo$/, /.bar$/ ]
+      }});
 
-      expect(tree.shouldBeIgnored('blah/blah/blah.foo')).to.be.ok();
-      expect(tree.shouldBeIgnored('blah/blah/blah.bar')).to.be.ok();
-      expect(tree.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok();
+      expect(node.shouldBeIgnored('blah/blah/blah.foo')).to.be.ok;
+      expect(node.shouldBeIgnored('blah/blah/blah.bar')).to.be.ok;
+      expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok;
     });
 
     it('returns false if the path is included in an include filter', function() {
-      tree.filterFromCache.include = [ /.foo$/, /.bar$/ ];
+      var node = new CachingWriter([sourcePath], { filterFromCache: {
+        include: [ /.foo$/, /.bar$/ ]
+      }});
 
-      expect(tree.shouldBeIgnored('blah/blah/blah.foo')).to.not.be.ok();
-      expect(tree.shouldBeIgnored('blah/blah/blah.bar')).to.not.be.ok();
+      expect(node.shouldBeIgnored('blah/blah/blah.foo')).to.not.be.ok;
+      expect(node.shouldBeIgnored('blah/blah/blah.bar')).to.not.be.ok;
     });
 
     it('returns true if the path is not included in an include filter', function() {
-      tree.filterFromCache.include = [ /.foo$/, /.bar$/ ];
+      var node = new CachingWriter([sourcePath], { filterFromCache: {
+        include: [ /.foo$/, /.bar$/ ]
+      }});
 
-      expect(tree.shouldBeIgnored('blah/blah/blah.baz')).to.be.ok();
+      expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.be.ok;
     });
 
     it('returns false if no patterns were used', function() {
-      expect(tree.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok();
+      var node = new CachingWriter([sourcePath], {});
+
+      expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok;
     });
 
     it('uses a cache to ensure we do not recalculate the filtering on subsequent attempts', function() {
-      expect(tree.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok();
+      var node = new CachingWriter([sourcePath], {});
+
+      expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok;
 
       // changing the filter mid-run should have no result on
       // previously calculated paths
-      tree.filterFromCache.include = [ /.foo$/, /.bar$/ ];
+      node._filterFromCache.include = [ /.foo$/, /.bar$/ ];
 
-      expect(tree.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok();
+      expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok;
     });
   });
 
   describe('listFiles', function() {
-    var tree, listFiles;
+    var listFiles;
 
-    beforeEach(function() {
-      tree = new CachingWriter([sourcePath]);
-      tree.updateCache = function(srcDirs, destDir){
+    function getListFilesFor(filterFromCache) {
+      setupCachingWriter([sourcePath], { filterFromCache: filterFromCache }, function() {
+        var writer = this;
         listFiles = this.listFiles().map(function(p) {
-          return path.relative(srcDirs[0], p);
+          return path.relative(writer.inputPaths[0], p);
         });
-      };
-    });
+      });
+      return expectRebuild().then(function() {
+        return listFiles;
+      });
+    }
 
     it('returns an array of files keyed', function() {
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function() {
-        expect(listFiles).to.eql(['core.js', 'main.js']);
-      });
+      return expect(getListFilesFor({})).to.eventually.deep.equal(['core.js', 'main.js']);
     });
 
     it('returns an array of files keyed including only those in the include filter', function() {
-      tree.filterFromCache.include = [ /core\.js$/ ];
-      builder = new broccoli.Builder(tree);
-
-      return builder.build().then(function() {
-        expect(listFiles).to.eql(['core.js']);
-      });
+      return expect(getListFilesFor({
+        include: [ /core\.js$/ ]
+      })).to.eventually.deep.equal(['core.js']);
     });
 
     it('returns an array of files keyed ignoring those in the exclude filter', function() {
-      tree.filterFromCache.exclude = [ /main\.js$/ ];
-      builder = new broccoli.Builder(tree);
-
-      return builder.build().then(function() {
-        expect(listFiles).to.eql(['core.js']);
-      });
+      return expect(getListFilesFor({
+        exclude: [ /main\.js$/ ]
+      })).to.eventually.deep.equal(['core.js']);
     });
 
     it('returns an array of files keyed both include & exclude filters', function() {
-      tree.filterFromCache.include = [ /\.js$/ ];
-      tree.filterFromCache.exclude = [ /core\.js$/ ];
-
-      builder = new broccoli.Builder(tree);
-
-      return builder.build().then(function() {
-        expect(listFiles).to.eql(['main.js']);
-      });
+      return expect(getListFilesFor({
+        include: [ /\.js$/ ],
+        exclude: [ /core\.js$/ ]
+      })).to.eventually.deep.equal(['main.js']);
     });
   });
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -365,56 +365,22 @@ describe('broccoli-caching-writer', function() {
     });
   });
 
-  describe('extend', function() {
-    it('sets the methods correctly', function() {
-      var TestPlugin = CachingWriter.extend({
-        foo: function() {}
-      });
-
-      expect(TestPlugin).to.be.a(Function);
-      expect(TestPlugin.prototype.foo).to.be.a(Function);
-    });
-
-    it('calls CachingWriter constructor', function () {
-      var MyPlugin = CachingWriter.extend({});
-      var instance = new MyPlugin(['foo']);
-      expect(instance.inputTrees).to.eql(['foo']);
-    });
-
-    it('can write files to destDir, and they will be in the final output', function(){
-      var TestWriter = CachingWriter.extend({
-        updateCache: function(srcDir, destDir) {
-          fs.writeFileSync(destDir + '/something-cooler.js', 'whoa', {encoding: 'utf8'});
-        }
-      });
-      var tree = new TestWriter([sourcePath]);
-
-      builder = new broccoli.Builder(tree);
-      return builder.build().then(function(result) {
-        var dir = result.directory;
-        expect(fs.readFileSync(dir + '/something-cooler.js', {encoding: 'utf8'})).to.equal('whoa');
-      });
-    });
-  });
-
   describe('listFiles', function() {
     var tree, listFiles;
 
     beforeEach(function() {
       tree = new CachingWriter([sourcePath]);
-      tree.updateCache = function(srcDir, destDir){
-        listFiles = this.listFiles();
+      tree.updateCache = function(srcDirs, destDir){
+        listFiles = this.listFiles().map(function(p) {
+          return path.relative(srcDirs[0], p);
+        });
       };
     });
 
     it('returns an array of files keyed', function() {
       builder = new broccoli.Builder(tree);
       return builder.build().then(function() {
-        expect(listFiles).to.eql([
-          path.normalize('tests/fixtures/sample-project/core.js'),
-          path.normalize('tests/fixtures/sample-project/main.js')
-        ]);
-        expect(listFiles.length).to.equal(2);
+        expect(listFiles).to.eql(['core.js', 'main.js']);
       });
     });
 
@@ -423,10 +389,7 @@ describe('broccoli-caching-writer', function() {
       builder = new broccoli.Builder(tree);
 
       return builder.build().then(function() {
-        expect(listFiles).to.eql([
-          path.normalize('tests/fixtures/sample-project/core.js')
-        ]);
-        expect(listFiles.length).to.equal(1);
+        expect(listFiles).to.eql(['core.js']);
       });
     });
 
@@ -435,10 +398,7 @@ describe('broccoli-caching-writer', function() {
       builder = new broccoli.Builder(tree);
 
       return builder.build().then(function() {
-        expect(listFiles).to.eql([
-          path.normalize('tests/fixtures/sample-project/core.js')
-        ]);
-        expect(listFiles.length).to.equal(1);
+        expect(listFiles).to.eql(['core.js']);
       });
     });
 
@@ -449,10 +409,7 @@ describe('broccoli-caching-writer', function() {
       builder = new broccoli.Builder(tree);
 
       return builder.build().then(function() {
-        expect(listFiles).to.eql([
-          path.normalize('tests/fixtures/sample-project/main.js')
-        ]);
-        expect(listFiles.length).to.equal(1);
+        expect(listFiles).to.eql(['main.js']);
       });
     });
   });

--- a/tests/index.js
+++ b/tests/index.js
@@ -131,6 +131,19 @@ describe('broccoli-caching-writer', function() {
         .then(function() { fs.writeFileSync(dummyJSChangedFile, 'bergh'); })
         .then(expectRebuild);
     });
+
+    it('when inputFiles is given, calls updateCache only when any of those files is changed', function() {
+      setupCachingWriter([sourcePath], {
+        inputFiles: ['core.js'] // existingJSFile
+      });
+
+      return expectRebuild()
+        .then(function() { fs.writeFileSync(dummyChangedFile, 'bergh'); })
+        .then(expectNoRebuild)
+        .then(function() { fs.writeFileSync(existingJSFile, '"YIPPIE"\n"KI-YAY!"\n'); })
+        .then(expectRebuild)
+        .finally(function() { fs.writeFileSync(existingJSFile, '"YIPPIE"\n'); });
+    });
   });
 
   describe('build', function() {

--- a/tests/jshint.js
+++ b/tests/jshint.js
@@ -1,0 +1,1 @@
+require('mocha-jshint')();


### PR DESCRIPTION
As requested by @stefanpenner. First three commits are actually good to merge I think.

Fourth one still requires updating to README, and it probably also makes sense to get the API to mimic Plugin, so that it's a drop-in-replacement for broccoli-plugin. I'll do that soon.