### PR TITLE
`init` example should call _super

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ var CachingWriter = require('broccoli-caching-writer');
 
 module.exports = CachingWriter.extend({
   init: function(inputTrees, options) {
+    this._super.apply(this, arguments);
+
     /* do additional setup here */
   },
 


### PR DESCRIPTION
If excluded, it results in "No inputTree/inputTrees set on tree: CoreObject"