### PR TITLE
Call super on init in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ var CachingWriter = require('broccoli-caching-writer');
 
 module.exports = CachingWriter.extend({
   init: function(inputTrees, options) {
+    this._super(inputTrees);
+
     /* do additional setup here */
   },
 


### PR DESCRIPTION
If excluded: `No inputTree/inputTrees set on tree: CoreObject`