### PR TITLE
only walk sync inputs that match inputFiles globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,12 +43,14 @@ function CachingWriter (inputNodes, options) {
   }
 }
 
-CachingWriter.prototype.debug = function() {
-  return this._debug || (this._debug = debugGenerator(
-    'broccoli-caching-writer:' +
-    this._name +
-    (this._annotation ? (' > [' + this._annotation + ']') : '')));
-};
+Object.defineProperty(CachingWriter.prototype, 'debug', {
+  get: function() {
+    return this._debug || (this._debug = debugGenerator(
+      'broccoli-caching-writer:' +
+        this._name +
+        (this._annotation ? (' > [' + this._annotation + ']') : '')));
+  }
+});
 
 CachingWriter.prototype._resetStats = function() {
   this._stats = {
@@ -86,7 +88,7 @@ CachingWriter.prototype._conditionalBuild = function () {
     var fullPath =  dir + '/' + relativePath;
     /*jshint validthis:true */
     this._stats.stats++;
-    return new Key('file', fullPath, relativePath, fs.statSync(fullPath), undefined, this.debug());
+    return new Key('file', fullPath, relativePath, fs.statSync(fullPath), undefined, this.debug);
   }
 
   for (var i = 0, l = writer.inputPaths.length; i < l; i++) {
@@ -95,17 +97,17 @@ CachingWriter.prototype._conditionalBuild = function () {
     var inputFiles;
 
     if (canUseInputFiles(this._inputFiles)) {
-      this.debug()('using inputFiles directly');
+      this.debug('using inputFiles directly');
       inputFiles = this._inputFiles;
     } else {
-      this.debug()('walking %o', this.inputFiles);
+      this.debug('walking %o', this.inputFiles);
       inputFiles = walkSync(dir,  this.inputFiles);
     }
 
     var files = inputFiles.filter(shouldNotBeIgnored, this).map(keyForFile, this);
     this._stats.files += files.length;
 
-    key = new Key('directory', dir, '/', fs.statSync(dir), files, this.debug());
+    key = new Key('directory', dir, '/', fs.statSync(dir), files, this.debug);
 
     var lastKey = writer._lastKeys[i];
     lastKeys.push(key);
@@ -116,8 +118,8 @@ CachingWriter.prototype._conditionalBuild = function () {
   }
 
   this._stats.inputPaths = writer.inputPaths;
-  this.debug()('%o', this._stats);
-  this.debug()('derive cacheKey in %dms', new Date() - start);
+  this.debug('%o', this._stats);
+  this.debug('derive cacheKey in %dms', new Date() - start);
   this._resetStats();
 
   if (invalidateCache) {
@@ -132,14 +134,14 @@ CachingWriter.prototype._conditionalBuild = function () {
         fs.mkdirSync(writer.outputPath);
       }).finally(function() {
 
-        this.debug()('purge output in %dms', new Date() - start);
+        this.debug('purge output in %dms', new Date() - start);
         start = new Date();
       }.bind(this));
     }
     return promise.then(function() {
       return writer.build();
     }).finally( function() {
-      this.debug()('rebuilding cache in %dms', new Date() - start);
+      this.debug('rebuilding cache in %dms', new Date() - start);
     }.bind(this));
   }
 };

--- a/index.js
+++ b/index.js
@@ -184,4 +184,23 @@ CachingWriter.prototype.shouldBeIgnored = function (fullPath) {
   return (this._shouldBeIgnoredCache[fullPath] = false);
 };
 
+// Returns a list of matched files
+CachingWriter.prototype.listFiles = function() {
+  function listFiles(keys, files) {
+    for (var i=0; i< keys.length; i++) {
+      var key = keys[i];
+      if (key.type === 'file') {
+        files.push(key.fullPath);
+      } else {
+        var children = key.children;
+        if(children && children.length > 0) {
+          listFiles(children, files);
+        }
+      }
+    }
+    return files;
+  }
+  return listFiles(this._lastKeys, []);
+};
+
 module.exports = CachingWriter;

--- a/index.js
+++ b/index.js
@@ -95,8 +95,10 @@ CachingWriter.prototype._conditionalBuild = function () {
     var inputFiles;
 
     if (canUseInputFiles(this._inputFiles)) {
+      this.debug()('using inputFiles directly');
       inputFiles = this._inputFiles;
     } else {
+      this.debug()('walking %o', this.inputFiles);
       inputFiles = walkSync(dir,  this.inputFiles);
     }
 
@@ -114,6 +116,7 @@ CachingWriter.prototype._conditionalBuild = function () {
   }
 
   this._stats.inputPaths = writer.inputPaths;
+  this.debug()('%o', this._stats);
   this.debug()('derive cacheKey in %dms', new Date() - start);
   this._resetStats();
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ CachingWriter.prototype._conditionalBuild = function () {
     var fullPath =  dir + '/' + relativePath;
     /*jshint validthis:true */
     this._stats.stats++;
-    return new Key('file', fullPath, relativePath, fs.statSync(fullPath), this.debug());
+    return new Key('file', fullPath, relativePath, fs.statSync(fullPath), undefined, this.debug());
   }
 
   for (var i = 0, l = writer.inputPaths.length; i < l; i++) {
@@ -103,7 +103,7 @@ CachingWriter.prototype._conditionalBuild = function () {
     var files = inputFiles.filter(shouldNotBeIgnored, this).map(keyForFile, this);
     this._stats.files += files.length;
 
-    key = new Key('dir', dir, '/', fs.statSync(dir), files, this.debug());
+    key = new Key('directory', dir, '/', fs.statSync(dir), files, this.debug());
 
     var lastKey = writer._lastKeys[i];
     lastKeys.push(key);

--- a/index.js
+++ b/index.js
@@ -114,10 +114,11 @@ CachingWriter.prototype._conditionalBuild = function () {
   }
 
   this._stats.inputPaths = writer.inputPaths;
-  this.debug()('rebuild %o in %dms', this._stats, new Date() - start);
+  this.debug()('derive cacheKey in %dms', new Date() - start);
   this._resetStats();
 
   if (invalidateCache) {
+    start = new Date();
     writer._lastKeys = lastKeys;
 
     var promise = RSVP.Promise.resolve();
@@ -126,11 +127,17 @@ CachingWriter.prototype._conditionalBuild = function () {
         return rimraf(writer.outputPath);
       }).then(function() {
         fs.mkdirSync(writer.outputPath);
-      });
+      }).finally(function() {
+
+        this.debug()('purge output in %dms', new Date() - start);
+        start = new Date();
+      }.bind(this));
     }
     return promise.then(function() {
       return writer.build();
-    });
+    }).finally( function() {
+      this.debug()('rebuilding cache in %dms', new Date() - start);
+    }.bind(this));
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lodash-node": "^3.2.0",
     "rimraf": "^2.2.8",
     "rsvp": "^3.0.17",
-    "symlink-or-copy": "^1.0.0"
+    "symlink-or-copy": "^1.0.0",
+    "walk-sync": "^0.2.0"
   },
   "devDependencies": {
     "broccoli": "^0.13.0",

--- a/tests/index.js
+++ b/tests/index.js
@@ -284,45 +284,6 @@ describe('broccoli-caching-writer', function() {
       expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok;
     });
   });
-
-  describe('listFiles', function() {
-    var listFiles;
-
-    function getListFilesFor(options) {
-      setupCachingWriter([sourcePath], options, function() {
-        var writer = this;
-        listFiles = this.listFiles().map(function(p) {
-          return path.relative(writer.inputPaths[0], p);
-        });
-      });
-      return expectRebuild().then(function() {
-        return listFiles;
-      });
-    }
-
-    it('returns an array of files keyed', function() {
-      return expect(getListFilesFor({})).to.eventually.deep.equal(['core.js', 'main.js']);
-    });
-
-    it('returns an array of files keyed including only those in the include filter', function() {
-      return expect(getListFilesFor({
-        cacheInclude: [ /core\.js$/ ]
-      })).to.eventually.deep.equal(['core.js']);
-    });
-
-    it('returns an array of files keyed ignoring those in the exclude filter', function() {
-      return expect(getListFilesFor({
-        cacheExclude: [ /main\.js$/ ]
-      })).to.eventually.deep.equal(['core.js']);
-    });
-
-    it('returns an array of files keyed both include & exclude filters', function() {
-      return expect(getListFilesFor({
-        cacheInclude: [ /\.js$/ ],
-        cacheExclude: [ /core\.js$/ ]
-      })).to.eventually.deep.equal(['main.js']);
-    });
-  });
 });
 
 var canUseInputFiles = require('../can-use-input-files');

--- a/tests/index.js
+++ b/tests/index.js
@@ -132,7 +132,7 @@ describe('broccoli-caching-writer', function() {
         .then(expectRebuild);
     });
 
-    it('when inputFiles is given, calls updateCache only when any of those files is changed', function() {
+    it('when inputFiles is given, calls updateCache only when any of those files are changed', function() {
       setupCachingWriter([sourcePath], {
         inputFiles: ['core.js'] // existingJSFile
       });

--- a/tests/index.js
+++ b/tests/index.js
@@ -284,6 +284,45 @@ describe('broccoli-caching-writer', function() {
       expect(node.shouldBeIgnored('blah/blah/blah.baz')).to.not.be.ok;
     });
   });
+
+  describe('listFiles', function() {
+    var listFiles;
+
+    function getListFilesFor(options) {
+      setupCachingWriter([sourcePath], options, function() {
+        var writer = this;
+        listFiles = this.listFiles().map(function(p) {
+          return path.relative(writer.inputPaths[0], p);
+        });
+      });
+      return expectRebuild().then(function() {
+        return listFiles;
+      });
+    }
+
+    it('returns an array of files keyed', function() {
+      return expect(getListFilesFor({})).to.eventually.deep.equal(['core.js', 'main.js']);
+    });
+
+    it('returns an array of files keyed including only those in the include filter', function() {
+      return expect(getListFilesFor({
+        cacheInclude: [ /core\.js$/ ]
+      })).to.eventually.deep.equal(['core.js']);
+    });
+
+    it('returns an array of files keyed ignoring those in the exclude filter', function() {
+      return expect(getListFilesFor({
+        cacheExclude: [ /main\.js$/ ]
+      })).to.eventually.deep.equal(['core.js']);
+    });
+
+    it('returns an array of files keyed both include & exclude filters', function() {
+      return expect(getListFilesFor({
+        cacheInclude: [ /\.js$/ ],
+        cacheExclude: [ /core\.js$/ ]
+      })).to.eventually.deep.equal(['main.js']);
+    });
+  });
 });
 
 var canUseInputFiles = require('../can-use-input-files');


### PR DESCRIPTION
- [x] fix failing tests
- [x] add back `listFiles`

This improves the scenario, where the `input` to BCW is much larger then the `inputFiles` globs match against. In the scenario where we can prune entire trees early like `['very/explicit/root/**/*.js']`, we can see  a nice speedup.

In a variation of the stress app, this reduces SimpleConcat key dervation time from 2500ms -> 100ms