### PR TITLE
use walkSync.entries to prevent double inputTree walk

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,14 +215,14 @@ CachingWriter.prototype.listFiles = function() {
 module.exports = CachingWriter;
 
 function keyForDir(dir, children, debug) {
-  var stat = fs.statSync(dir);
-
+  // no need to stat dir, we don't care about anything other then that they are
+  // a dir
   return new Key({
     relativePath: '/',
     basePath: dir,
-    mode: stat.mode,
-    size: stat.size,
-    mtime: stat.mtime.getTime(),
+    mode: 16877,
+    size: 0,
+    mtime: 0,
     isDirectory: function() { return  true; }
   }, children, debug);
 }

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ CachingWriter.prototype._conditionalBuild = function () {
   var start = new Date();
 
   var invalidateCache = false;
-  var key, dir;
+  var dir;
   var lastKeys = [];
 
   if (!writer._lastKeys) {
@@ -86,33 +86,42 @@ CachingWriter.prototype._conditionalBuild = function () {
 
   function keyForFile(relativePath) {
     var fullPath =  dir + '/' + relativePath;
-    /*jshint validthis:true */
-    this._stats.stats++;
-    return new Key('file', fullPath, relativePath, fs.statSync(fullPath), undefined, this.debug);
-  }
 
+    var stats = fs.statSync(fullPath);
+
+    /*jshint validthis:true */
+    return new Key({
+      relativePath: relativePath,
+      basePath: dir,
+      mode: stats.mode,
+      size: stats.size,
+      mtime: stats.mtime.getTime(),
+      isDirectory: function() {
+        return false;
+      }
+    }, undefined, this.debug);
+  }
   for (var i = 0, l = writer.inputPaths.length; i < l; i++) {
     dir = writer.inputPaths[i];
 
-    var inputFiles;
+    var files;
 
     if (canUseInputFiles(this._inputFiles)) {
       this.debug('using inputFiles directly');
-      inputFiles = this._inputFiles;
+      files = this._inputFiles.filter(shouldNotBeIgnored, this).map(keyForFile, this);
     } else {
       this.debug('walking %o', this.inputFiles);
-      inputFiles = walkSync(dir,  this.inputFiles);
+      files = walkSync.entries(dir,  this.inputFiles).filter(entriesShouldNotBeIgnored, this).map(keyForEntry, this);
     }
 
-    var files = inputFiles.filter(shouldNotBeIgnored, this).map(keyForFile, this);
     this._stats.files += files.length;
 
-    key = new Key('directory', dir, '/', fs.statSync(dir), files, this.debug);
-
     var lastKey = writer._lastKeys[i];
+    var key = keyForDir(dir, files, this.debug);
+
     lastKeys.push(key);
 
-    if (!invalidateCache /* short circuit */ && !key.equal(lastKey)) {
+    if (!invalidateCache /* short circuit */ && !key.isEqual(lastKey)) {
       invalidateCache = true;
     }
   }
@@ -189,13 +198,13 @@ CachingWriter.prototype.listFiles = function() {
   function listFiles(keys, files) {
     for (var i=0; i< keys.length; i++) {
       var key = keys[i];
-      if (key.type === 'file') {
-        files.push(key.fullPath);
-      } else {
+      if (key.isDirectory()) {
         var children = key.children;
         if(children && children.length > 0) {
           listFiles(children, files);
         }
+      } else {
+        files.push(key.fullPath);
       }
     }
     return files;
@@ -204,3 +213,27 @@ CachingWriter.prototype.listFiles = function() {
 };
 
 module.exports = CachingWriter;
+
+function keyForDir(dir, children, debug) {
+  var stat = fs.statSync(dir);
+
+  return new Key({
+    relativePath: '/',
+    basePath: dir,
+    mode: stat.mode,
+    size: stat.size,
+    mtime: stat.mtime.getTime(),
+    isDirectory: function() { return  true; }
+  }, children, debug);
+}
+
+function entriesShouldNotBeIgnored(entry) {
+  /*jshint validthis:true */
+  return !this.shouldBeIgnored(entry.relativePath);
+}
+
+function keyForEntry(entry) {
+  /*jshint validthis:true */
+  return new Key(entry, undefined, this.debug);
+}
+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "rimraf": "^2.2.8",
     "rsvp": "^3.0.17",
     "symlink-or-copy": "^1.0.0",
-    "walk-sync": "^0.2.0"
+    "walk-sync": "^0.2.5"
   },
   "devDependencies": {
     "broccoli": "^0.13.0",


### PR DESCRIPTION
Affectively cuts input reading costs in 1/2.

- [x] pending https://github.com/joliss/node-walk-sync/pull/11