### PR TITLE
updated broccoli

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "walk-sync": "^0.2.5"
   },
   "devDependencies": {
-    "broccoli": "^0.13.0",
+    "broccoli": "^0.16.9",
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
     "mocha": "^2.2.5",


### PR DESCRIPTION
old broccoli version had an eventual dependency on deprecated lodash-node