### PR TITLE
Change list{Files,Entries} to return sorted results

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Call this base class constructor from your subclass constructor.
         *Note, in the case when a file or directory matches both an include and exlude pattern, the exclude pattern wins*
 
 ## `plugin.listFiles`
-list files matched, helpful as it allows us avoid a second glob
+list files matched, helpful as it allows us avoid a second glob, lexicographically sorted by relativePath.
 
 ## `plugin.listEntries`
-list entries (stat objects) of files matched, helpful when further FS information is required on rebuild.
+list entries (stat objects) of files matched, helpful when further FS information is required on rebuild, lexicographically sorted by relativePath.
 
 ## ZOMG!!! TESTS?!?!!?
 

--- a/index.js
+++ b/index.js
@@ -215,7 +215,20 @@ CachingWriter.prototype.listEntries = function() {
     }
     return files;
   }
-  return listEntries(this._lastKeys, []);
+
+  return listEntries(this._lastKeys, []).sort(function (a, b) {
+      var pathA = a.relativePath;
+      var pathB = b.relativePath;
+
+      if (pathA === pathB) {
+        return 0;
+      } else if (pathA < pathB) {
+        return -1;
+      } else {
+        return 1;
+      }
+    }
+  );
 };
 
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -282,15 +282,20 @@ describe('broccoli-caching-writer', function() {
   });
 
   describe('listFiles', function() {
-    var listFiles;
+    function getListFilesFor(options, sourcePaths) {
+      var listFiles;
 
-    function getListFilesFor(options) {
-      setupCachingWriter([sourcePath], options, function() {
+      if (arguments.length < 2) {
+        sourcePaths = [sourcePath];
+      }
+
+      setupCachingWriter(sourcePaths, options, function() {
         var writer = this;
-        listFiles = this.listFiles().map(function(p) {
-          return path.relative(writer.inputPaths[0], p);
+        listFiles = this.listFiles().map(function(fullPath) {
+          return path.basename(fullPath);
         });
       });
+
       return expectRebuild().then(function() {
         return listFiles;
       });
@@ -318,16 +323,32 @@ describe('broccoli-caching-writer', function() {
         cacheExclude: [ /core\.js$/ ]
       })).to.eventually.deep.equal(['main.js']);
     });
+
+    it('returns a sorted array', function() {
+      return expect(getListFilesFor(
+        {}, [sourcePath, secondaryPath]
+      )).to.eventually.deep.equal([
+        'bar.js',
+        'core.js',
+        'foo-baz.js',
+        'foo.js',
+        'main.js',
+      ]);
+    });
   });
 
   describe('listEntries', function() {
-    var listEntries;
+    function getListEntriesFor(options, sourcePaths) {
+      var listEntries;
 
-    function getListEntriesFor(options) {
-      setupCachingWriter([sourcePath], options, function() {
+      if (arguments.length < 2) {
+        sourcePaths = [sourcePath];
+      }
+
+      setupCachingWriter(sourcePaths, options, function() {
         var writer = this;
-        listEntries = this.listEntries().map(function(p) {
-          return path.relative(writer.inputPaths[0], p.fullPath);
+        listEntries = this.listEntries().map(function(entry) {
+          return path.basename(entry.fullPath);
         });
       });
 
@@ -357,6 +378,19 @@ describe('broccoli-caching-writer', function() {
         cacheInclude: [ /\.js$/ ],
         cacheExclude: [ /core\.js$/ ]
       })).to.eventually.deep.equal(['main.js']);
+    });
+
+
+    it('returns a sorted array', function() {
+      return expect(getListEntriesFor(
+        {}, [sourcePath, secondaryPath]
+      )).to.eventually.deep.equal([
+        'bar.js',
+        'core.js',
+        'foo-baz.js',
+        'foo.js',
+        'main.js',
+      ]);
     });
   });
 });


### PR DESCRIPTION
Previously the order was undefined behavior.  Now results are sorted
lexicographically by relativePath.