### PR TITLE
Fix: reference to nonexistant `inputFiles`

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,8 +108,8 @@ CachingWriter.prototype._conditionalBuild = function () {
       this.debug('using inputFiles directly');
       files = this._inputFiles.filter(shouldNotBeIgnored, this).map(keyForFile, this);
     } else {
-      this.debug('walking %o', this.inputFiles);
-      files = walkSync.entries(dir,  this.inputFiles).filter(entriesShouldNotBeIgnored, this).map(keyForEntry, this);
+      this.debug('walking %o', this._inputFiles);
+      files = walkSync.entries(dir,  this._inputFiles).filter(entriesShouldNotBeIgnored, this).map(keyForEntry, this);
     }
 
     this._stats.files += files.length;


### PR DESCRIPTION
I'd like to pass a glob pattern into `walkSync.entries` because this function is the source of a large bottleneck in my ember build pipeline.  It would be nice if sassOptions.includePaths was translated into this option. This is probably the first of a few changes necessary to support passing that glob pattern. In any event, this looks like a bug as this.inputFiles is not specified anywhere.

Note: I know this needs a test, but I wanted to get this up here while I was looking at it.
